### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -25,6 +25,6 @@
       "Jonathan Stowe <jns+git@gellyfish.co.uk>"
    ],
    "version" : "0.0.1",
-   "license" : "Artistic",
+   "license" : "Artistic-2.0",
    "description" : "Get a free server port for testing with"
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license